### PR TITLE
Add multiline literals, cleanup

### DIFF
--- a/src/ruby/Main.rb
+++ b/src/ruby/Main.rb
@@ -18,7 +18,7 @@ class Main
 
   preprocessed_emerald = PreProcessor.process_emerald()
   abstract_syntax_tree = Grammer.parse_grammar(preprocessed_emerald)
-  out = abstract_syntax_tree.to_html("")
+  out = abstract_syntax_tree.to_html
   puts out
   File.open("index.html", "w") do |file|
     file.write(out)

--- a/src/ruby/grammar/emerald.tt
+++ b/src/ruby/grammar/emerald.tt
@@ -38,7 +38,23 @@ grammar Emerald
 
   # Ex. h1 "test this out."
   rule text
-    h_num space* (( !"\n" . )*)? <Text>
+    h_num space* text_content? <Text>
+  end
+
+  rule text_content
+    multiline_literal / inline_literal
+  end
+
+  rule multiline_literal
+    "->" space* newline multiline_literal_body "$" <MultilineLiteral>
+  end
+
+  rule multiline_literal_body
+    ('\$' / !'$' .)*
+  end
+
+  rule inline_literal
+    ( !"\n" . )*
   end
 
   # tag space* string (0 or 1), attr_list (0 or 1)

--- a/src/ruby/index.emr
+++ b/src/ruby/index.emr
@@ -21,6 +21,13 @@ html
         h3 About
         p Emerald is a templating engine designed for use in multiple languages.
         p Emerald may be used as a templating engine for node, python, ruby, or go web applications.
+        h1 ->
+          this is some literal text, not an actual tag
+            with an indent
+          and multiple lines
+          and an e$cape character
+          p and a tag
+        p this is an actual tag now
 
       footer
         p Copyright Emerald Language 2016

--- a/src/ruby/index.html
+++ b/src/ruby/index.html
@@ -1,1 +1,17 @@
-<html><head><link rel='stylesheet' href="public/css/main.emr" /><script type='text/javascript' src="public/js/main.js"></script></head><body><nav><a>Emerald</a><a>Docs</a><a>Github</a></nav><header><h1>Emerald!</h1><h2>A templating engine for multiple languages.</h2></header><main><section><h3>About</h3><p>Emerald is a templating engine designed for use in multiple languages.</p><p>Emerald may be used as a templating engine for node, python, ruby, or go web applications.</p></section><footer><p>Copyright Emerald Language 2016</p></footer></main></body></html>
+<html></html><head></head><link rel='stylesheet' href="public/css/main.emr" />
+<script type='text/javascript' src="public/js/main.js"></script></head>
+<body></body><nav></nav><a>Emerald</a>
+<a>Docs</a>
+<a>Github</a></nav>
+<header></header><h1>Emerald!</h1>
+<h2>A templating engine for multiple languages.</h2></header>
+<main></main><section></section><h3>About</h3>
+<p>Emerald is a templating engine designed for use in multiple languages.</p>
+<p>Emerald may be used as a templating engine for node, python, ruby, or go web applications.</p>
+<h1>this is some literal text, not an actual tag
+  with an indent
+and multiple lines
+and an e$cape character
+p and a tag</h1>
+<p>this is an actual tag now</p></section>
+<footer></footer><p>Copyright Emerald Language 2016</p></footer></main></body></html>

--- a/src/ruby/nodes/Line.rb
+++ b/src/ruby/nodes/Line.rb
@@ -4,11 +4,13 @@ require 'treetop'
 require_relative 'Node'
 
 class Line < Node
-  def to_html(output)
+  def to_html
     e = elements[0]
 
     if e.is_a?(TagStatement) || e.is_a?(Text)
-      output += "<#{e.elements[0].text_value}>#{e.elements[2].text_value}</#{e.elements[0].text_value}>"
+      e.to_html
+    else
+      raise "well you shouldn't be here :("
     end
   end
 end

--- a/src/ruby/nodes/List.rb
+++ b/src/ruby/nodes/List.rb
@@ -5,19 +5,19 @@ require_relative 'Node'
 
 # TODO: Refactor this
 class List < Node
-  def to_html(output)
+  def to_html
     if elements[0].text_value == "styles"
-      elements[4].elements.each do |e|
-        output += "<link rel='stylesheet' href=#{e.text_value.strip} />"
-      end
+      elements[4].elements.map do |e|
+        "<link rel='stylesheet' href=#{e.text_value.strip} />"
+      end.join("\n")
     elsif elements[0].text_value == "scripts"
-      elements[4].elements.each do |e|
-        output += "<script type='text/javascript' src=#{e.text_value.strip}></script>"
-      end
+      elements[4].elements.map do |e|
+        "<script type='text/javascript' src=#{e.text_value.strip}></script>"
+      end.join("\n")
     elsif elements[0].text_value == "metas"
-      elements[4].elements.each do |e|
-      end
+      elements[4].elements.map do |e|
+        ""
+      end.join("\n")
     end
-    output
   end
 end

--- a/src/ruby/nodes/MultilineLiteral.rb
+++ b/src/ruby/nodes/MultilineLiteral.rb
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+
+require 'treetop'
+
+class MultilineLiteral < Treetop::Runtime::SyntaxNode
+  def to_html
+    multiline_literal_body
+      .text_value
+      .gsub('\$', '$') # Unescape preprocessor escaping
+      .rstrip
+  end
+end

--- a/src/ruby/nodes/Nested.rb
+++ b/src/ruby/nodes/Nested.rb
@@ -8,11 +8,9 @@ require_relative 'Node'
 # elements[0] is the tag statement, elements[4] is any nested html.
 #
 class Nested < Node
-  def to_html(output)
-    output += (
-      elements[0].to_html(output) +
-      elements[4].to_html(output) +
+  def to_html
+    elements[0].to_html +
+      elements[4].to_html +
       "</#{elements[0].elements[0].text_value}>"
-    )
   end
 end

--- a/src/ruby/nodes/Root.rb
+++ b/src/ruby/nodes/Root.rb
@@ -4,10 +4,9 @@ require 'treetop'
 require_relative 'Node'
 
 class Root < Node
-  def to_html(output)
-    elements.each do |e|
-      output += e.to_html("")
-    end
-    output
+  def to_html
+    elements
+      .map{|e| e.to_html}
+      .join("\n")
   end
 end

--- a/src/ruby/nodes/TagStatement.rb
+++ b/src/ruby/nodes/TagStatement.rb
@@ -4,7 +4,11 @@ require 'treetop'
 require_relative 'Node'
 
 class TagStatement < Node
-  def to_html(output)
+  def to_html
+
+    return "<#{elements[0].text_value}>#{elements[2].text_value}</#{elements[0].text_value}>"
+
+    # todo: make this work
     if elements[4].is_a?(AttributeList)
       output += ("<#{elements[0].text_value}#{elements[4].to_html()}>" +
                  "#{elements[2].text_value.delete! '(),'}")

--- a/src/ruby/nodes/Text.rb
+++ b/src/ruby/nodes/Text.rb
@@ -4,5 +4,12 @@ require 'treetop'
 
 class Text < Treetop::Runtime::SyntaxNode
   def to_html
+    "<#{h_num.text_value}>" + 
+      (
+        elements[2].is_a?(MultilineLiteral) ?
+        elements[2].to_html :
+        elements[2].text_value
+      ) +
+      "</#{h_num.text_value}>"
   end
 end


### PR DESCRIPTION
## Language changes
This allows you to have text content over multiple lines, for example:
```
h1 ->
  Hey here's some text
  on a few lines
```
...becomes:
```html
<h1>Hey here's some text
on a few lines</h1>
```

It removes only initial indentation and preserves the rest, so:
```
div
  h1 ->
    text
      with indentation
```
...becomes:
```
<p>
<h1>text
  with indentation
</h1>
</p>
```
Which will be useful for `code` and `script` tags, although right now it's only implemented in the `Text` rule.

## Preprocessor changes
It accomplishes this by adding a `$` in the preprocessor when the literal is finished, escaping any existing dollar signs inside the literal (these are unescaped again in codegen.)

## Codegen changes
I also changed codegen to not pass around an `output` string and instead just rely on return value, since it was relying on return value anyway.