### PR TITLE
Add context-changing function support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,9 @@ Metrics/AbcSize:
 
 Metrics/MethodLength:
   Max: 30
+
+Style/DoubleNegation:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false

--- a/src/ruby/Grammar.rb
+++ b/src/ruby/Grammar.rb
@@ -8,6 +8,8 @@ require 'treetop'
 Dir[File.dirname(__FILE__) + '/nodes/*.rb'].each { |f| require f }
 
 Treetop.load __dir__ + '/grammar/tokens'
+Treetop.load __dir__ + '/grammar/variables'
+Treetop.load __dir__ + '/grammar/scopes'
 Treetop.load __dir__ + '/grammar/emerald'
 
 #
@@ -38,7 +40,7 @@ module Grammar
     puts '===================================='
     text.each_line.with_index { |line, i| puts "#{i + 1} #{line}" }
     puts "====================================\n\n"
-    puts parser.failure_reason
+    puts @parser.failure_reason
     puts "\n"
   end
 

--- a/src/ruby/PreProcessor.rb
+++ b/src/ruby/PreProcessor.rb
@@ -47,7 +47,7 @@ class PreProcessor
   def check_new_indent(new_indent)
     if new_indent > @current_indent
       new_indent_greater(new_indent)
-    elsif new_indent < @current_indent && new_indent.nonzero?
+    elsif new_indent < @current_indent
       new_indent_lesser(new_indent)
     end
   end

--- a/src/ruby/grammar/emerald.tt
+++ b/src/ruby/grammar/emerald.tt
@@ -4,15 +4,21 @@
 #
 grammar Emerald
   include Tokens
+  include Scopes
+  include Variables
 
   rule main
-    (list / nested / line / comment)+ <Root>
+    (scope / list / nested / line / comment)+ <Root>
   end
 
   # A nested statement is a tag statement followed by a newline and an
   # a block scoped by braces.
   rule nested
     tag_statement newline lbrace newline main rbrace newline <Nested>
+  end
+
+  rule scope
+    fn:scope_fn lbrace newline body:main rbrace newline <Scope>
   end
 
   # Comment has optional newline, so it's not included in the first sequence
@@ -55,14 +61,6 @@ grammar Emerald
 
   rule inline_literal
     ( variable / !"\n" . )* <InlineLiteral>
-  end
-
-  rule variable
-    '|' variable_name '|' <Variable>
-  end
-
-  rule variable_name
-    (!'|' !'.' .)+ ('.' variable_name)*
   end
 
   # tag space* string (0 or 1), attr_list (0 or 1)

--- a/src/ruby/grammar/scopes.tt
+++ b/src/ruby/grammar/scopes.tt
@@ -1,0 +1,48 @@
+#
+# Context free grammar of tokens (terminal
+# nodes) for the Emerald language.
+#
+grammar Scopes
+  include Variables
+
+  rule scope_fn
+    (given / unless / each / with) "\n"
+    <ScopeFn>
+  end
+
+  rule given
+    "given" space* boolean_expr <Given>
+  end
+
+  rule unless
+    "unless" space* boolean_expr <Unless>
+  end
+
+  rule with
+    "with" space* variable_name <With>
+  end
+
+  rule each
+    "each" space* collection:variable_name
+    space* "as" space* val_name:variable_name
+    indexed:(',' space* key_name:variable_name)?
+    <Each>
+  end
+
+  rule boolean_expr
+    binary_expr / unary_expr
+  end
+
+  rule binary_expr
+    lhs:unary_expr
+    space+ op:("and" / "or") space*
+    rhs:boolean_expr
+    <BinaryExpr>
+  end
+
+  rule unary_expr
+    negated:("not" space+)?
+    (val:variable_name / '(' space* val:boolean_expr space* ')')
+    <UnaryExpr>
+  end
+end

--- a/src/ruby/grammar/variables.tt
+++ b/src/ruby/grammar/variables.tt
@@ -1,0 +1,10 @@
+# Variable support in Emerald
+grammar Variables
+  rule variable
+    '|' variable_name '|' <Variable>
+  end
+
+  rule variable_name
+    [a-zA-Z0-9_]+ ('.' variable_name)* <VariableName>
+  end
+end

--- a/src/ruby/nodes/BaseScopeFn.rb
+++ b/src/ruby/nodes/BaseScopeFn.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'treetop'
+
+# Base class for scope functions
+class BaseScopeFn < Treetop::Runtime::SyntaxNode
+  def to_html(_body, _context)
+    raise 'not implemented :('
+  end
+end

--- a/src/ruby/nodes/BinaryExpr.rb
+++ b/src/ruby/nodes/BinaryExpr.rb
@@ -4,7 +4,7 @@
 require 'treetop'
 require_relative 'BooleanExpr'
 
-# Variable interpolation in a template
+# A boolean expression with two children and an operator
 class BinaryExpr < BooleanExpr
   def truthy?(context)
     case op.text_value

--- a/src/ruby/nodes/BinaryExpr.rb
+++ b/src/ruby/nodes/BinaryExpr.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'treetop'
+require_relative 'BooleanExpr'
+
+# Variable interpolation in a template
+class BinaryExpr < BooleanExpr
+  def truthy?(context)
+    case op.text_value
+    when 'and'
+      lhs.truthy?(context) && rhs.truthy?(context)
+    when 'or'
+      lhs.truthy?(context) || rhs.truthy?(context)
+    end
+  end
+end

--- a/src/ruby/nodes/BooleanExpr.rb
+++ b/src/ruby/nodes/BooleanExpr.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'treetop'
+
+# Variable interpolation in a template
+class BooleanExpr < Treetop::Runtime::SyntaxNode
+  def truthy?(context)
+    elements.first.truthy?(context)
+  end
+end

--- a/src/ruby/nodes/BooleanExpr.rb
+++ b/src/ruby/nodes/BooleanExpr.rb
@@ -3,7 +3,7 @@
 
 require 'treetop'
 
-# Variable interpolation in a template
+# The boolean condition for a logic statement
 class BooleanExpr < Treetop::Runtime::SyntaxNode
   def truthy?(context)
     elements.first.truthy?(context)

--- a/src/ruby/nodes/Each.rb
+++ b/src/ruby/nodes/Each.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'treetop'
+require_relative 'BaseScopeFn'
+
+# Base class for scope functions
+class Each < BaseScopeFn
+  def to_html(body, context)
+    vars = collection.content(context)
+    key_name = indexed.text_value.length.positive? ? indexed.key_name : nil
+
+    # TODO: clean up somehow
+    if vars.is_a? Hash
+      vars
+        .map do |var, key|
+          new_ctx = context.clone
+          new_ctx[val_name.text_value] = var
+          new_ctx[key_name.text_value] = key if key_name
+
+          body.to_html(new_ctx)
+        end
+        .join("\n")
+    elsif vars.is_a? Array
+      vars
+        .map.with_index do |var, idx|
+          new_ctx = context.clone
+          new_ctx[val_name.text_value] = var
+          new_ctx[key_name.text_value] = idx if key_name
+
+          body.to_html(new_ctx)
+        end
+        .join("\n")
+    else
+      raise 'bad variable type :('
+    end
+  end
+end

--- a/src/ruby/nodes/Each.rb
+++ b/src/ruby/nodes/Each.rb
@@ -4,7 +4,7 @@
 require 'treetop'
 require_relative 'BaseScopeFn'
 
-# Base class for scope functions
+# Function to map over elements in the context
 class Each < BaseScopeFn
   def to_html(body, context)
     vars = collection.content(context)

--- a/src/ruby/nodes/Given.rb
+++ b/src/ruby/nodes/Given.rb
@@ -4,7 +4,7 @@
 require 'treetop'
 require_relative 'BaseScopeFn'
 
-# Base class for scope functions
+# Renders if a condition is met
 class Given < BaseScopeFn
   def to_html(body, context)
     if boolean_expr.truthy?(context)

--- a/src/ruby/nodes/Given.rb
+++ b/src/ruby/nodes/Given.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'treetop'
+require_relative 'BaseScopeFn'
+
+# Base class for scope functions
+class Given < BaseScopeFn
+  def to_html(body, context)
+    if boolean_expr.truthy?(context)
+      body.to_html(context)
+    else
+      ''
+    end
+  end
+end

--- a/src/ruby/nodes/Scope.rb
+++ b/src/ruby/nodes/Scope.rb
@@ -4,11 +4,9 @@
 require 'treetop'
 require_relative 'Node'
 
-# A base piece of an Emerald file
-class Root < Node
+# Block that modifies the context
+class Scope < Node
   def to_html(context)
-    elements
-      .map { |e| e.to_html(context) }
-      .join("\n")
+    fn.to_html(body, context)
   end
 end

--- a/src/ruby/nodes/ScopeFn.rb
+++ b/src/ruby/nodes/ScopeFn.rb
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'treetop'
+require_relative 'BaseScopeFn'
+
+# Base class for scope functions
+class ScopeFn < BaseScopeFn
+  def to_html(body, context)
+    elements[0].to_html(body, context)
+  end
+end

--- a/src/ruby/nodes/UnaryExpr.rb
+++ b/src/ruby/nodes/UnaryExpr.rb
@@ -4,7 +4,7 @@
 require 'treetop'
 require_relative 'BooleanExpr'
 
-# Variable interpolation in a template
+# A boolean expression with one child
 class UnaryExpr < BooleanExpr
   def truthy?(context)
     if negated.text_value.length.positive?

--- a/src/ruby/nodes/UnaryExpr.rb
+++ b/src/ruby/nodes/UnaryExpr.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'treetop'
+require_relative 'BooleanExpr'
+
+# Variable interpolation in a template
+class UnaryExpr < BooleanExpr
+  def truthy?(context)
+    if negated.text_value.length.positive?
+      !elements[1].val.truthy?(context)
+    else
+      elements[1].val.truthy?(context)
+    end
+  end
+end

--- a/src/ruby/nodes/Unless.rb
+++ b/src/ruby/nodes/Unless.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'treetop'
+require_relative 'BaseScopeFn'
+
+# Base class for scope functions
+class Unless < BaseScopeFn
+  def to_html(body, context)
+    if boolean_expr.truthy?(context)
+      ''
+    else
+      body.to_html(context)
+    end
+  end
+end

--- a/src/ruby/nodes/Unless.rb
+++ b/src/ruby/nodes/Unless.rb
@@ -4,7 +4,7 @@
 require 'treetop'
 require_relative 'BaseScopeFn'
 
-# Base class for scope functions
+# Renders unless a condition is met
 class Unless < BaseScopeFn
   def to_html(body, context)
     if boolean_expr.truthy?(context)

--- a/src/ruby/nodes/Variable.rb
+++ b/src/ruby/nodes/Variable.rb
@@ -8,10 +8,7 @@ require_relative 'Node'
 class Variable < Node
   def to_html(context)
     variable_name
-      .text_value
-      .split('.')
-      .reduce(context) do |ctx, name|
-        ctx[name] || ctx[name.to_sym] || nil
-      end
+      .content(context)
+      .to_s
   end
 end

--- a/src/ruby/nodes/VariableName.rb
+++ b/src/ruby/nodes/VariableName.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'treetop'
+require_relative 'BooleanExpr'
+
+# Variable interpolation in a template
+class VariableName < BooleanExpr
+  def content(context)
+    text_value
+      .split('.')
+      .reduce(context) do |ctx, name|
+        ctx[name] || ctx[name.to_sym] || nil
+      end
+  end
+
+  def truthy?(context)
+    !!content(context)
+  end
+end

--- a/src/ruby/nodes/With.rb
+++ b/src/ruby/nodes/With.rb
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'treetop'
+require_relative 'BaseScopeFn'
+
+# Base class for scope functions
+class With < BaseScopeFn
+  def to_html(body, context)
+    var = elements[2].content(context)
+
+    body.to_html(var)
+  end
+end

--- a/src/ruby/nodes/With.rb
+++ b/src/ruby/nodes/With.rb
@@ -4,7 +4,7 @@
 require 'treetop'
 require_relative 'BaseScopeFn'
 
-# Base class for scope functions
+# Isolates the scope to a subset of the context
 class With < BaseScopeFn
   def to_html(body, context)
     var = elements[2].content(context)

--- a/src/test/EmeraldSuite.rb
+++ b/src/test/EmeraldSuite.rb
@@ -35,6 +35,143 @@ TEMPLATE_TESTS = [
   }
 ].freeze
 
+SCOPE_TESTS = [
+  {
+    context: {test: true},
+    in: <<~EMR,
+      given test
+        h1 True
+      unless test
+        h1 False
+    EMR
+    out: '<h1>True</h1>'
+  },
+  {
+    context: {test: false},
+    in: <<~EMR,
+      given test
+        h1 True
+      unless test
+        h1 False
+    EMR
+    out: '<h1>False</h1>'
+  },
+  {
+    context: {},
+    in: <<~EMR,
+      given test
+        h1 True
+      unless test
+        h1 False
+    EMR
+    out: '<h1>False</h1>'
+  },
+  {
+    context: {a: true, b: false},
+    in: <<~EMR,
+      given a or b
+        h1 True
+    EMR
+    out: '<h1>True</h1>'
+  },
+  {
+    context: {a: false, b: false},
+    in: <<~EMR,
+      given a or b
+        h1 True
+    EMR
+    out: ''
+  },
+  {
+    context: {a: true, b: true},
+    in: <<~EMR,
+      given a and b
+        h1 True
+    EMR
+    out: '<h1>True</h1>'
+  },
+  {
+    context: {a: true, b: false},
+    in: <<~EMR,
+      given a and b
+        h1 True
+    EMR
+    out: ''
+  },
+  {
+    context: {a: false},
+    in: <<~EMR,
+      given not a
+        h1 True
+    EMR
+    out: '<h1>True</h1>'
+  },
+  {
+    context: {a: true},
+    in: <<~EMR,
+      given not a
+        h1 True
+    EMR
+    out: ''
+  },
+  {
+    context: {a: true, b: true, c: true},
+    in: <<~EMR,
+      given a and b and c
+        h1 True
+    EMR
+    out: '<h1>True</h1>'
+  },
+  {
+    context: {a: false, b: true, c: true},
+    in: <<~EMR,
+      given a or (b and c)
+        h1 True
+    EMR
+    out: '<h1>True</h1>'
+  },
+  {
+    context: {a: false, b: true, c: true},
+    in: <<~EMR,
+      given a or (b and c)
+        h1 True
+    EMR
+    out: '<h1>True</h1>'
+  },
+  {
+    context: {a: [1, 2, 3]},
+    in: <<~EMR,
+      each a as element
+        h1 |element|
+    EMR
+    out: '<h1>1</h1> <h1>2</h1> <h1>3</h1>'
+  },
+  {
+    context: {a: ['a', 'b', 'c']},
+    in: <<~EMR,
+      each a as element, i
+        h1 |i|
+    EMR
+    out: '<h1>0</h1> <h1>1</h1> <h1>2</h1>'
+  },
+  {
+    context: {a: {b: 'c'}},
+    in: <<~EMR,
+      each a as v, k
+        h1 |v| |k|
+    EMR
+    out: '<h1>b c</h1>'
+  },
+  {
+    context: {a: {b: 'c'}},
+    in: <<~EMR,
+      with a
+        h1 |b|
+    EMR
+    out: '<h1>c</h1>'
+  }
+].freeze
+
 #
 # Unit testing for Emerald Language. Asserts that emerald passed in is
 # compiled to valid html, which is equivalent in semantic value.
@@ -44,8 +181,11 @@ class EmeraldSuite < Test::Unit::TestCase
     str.gsub(/\s+/, ' ').strip
   end
 
-  def test_templating
-    TEMPLATE_TESTS.each do |test|
+  def test_all
+    [
+      TEMPLATE_TESTS,
+      SCOPE_TESTS
+    ].flatten.each do |test|
       output = whitespace_agnostic test[:out]
       expected = whitespace_agnostic Emerald.convert(test[:in], test[:context])
 

--- a/src/test/preprocessor/emerald/general/scopes.emr
+++ b/src/test/preprocessor/emerald/general/scopes.emr
@@ -1,0 +1,4 @@
+given test
+  h1 True
+unless test
+  h1 False

--- a/src/test/preprocessor/intermediate/general/scopes.txt
+++ b/src/test/preprocessor/intermediate/general/scopes.txt
@@ -1,0 +1,8 @@
+given test
+{
+h1 True
+}
+unless test
+{
+h1 False
+}

--- a/src/test/treetop/TreetopSuite.rb
+++ b/src/test/treetop/TreetopSuite.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test/unit'
 require 'polyglot'
@@ -8,6 +9,8 @@ require 'treetop'
 Dir[__dir__ + '/../../ruby/nodes/*.rb'].each { |f| require_relative f }
 
 Treetop.load __dir__ + '/../../ruby/grammar/tokens'
+Treetop.load __dir__ + '/../../ruby/grammar/variables'
+Treetop.load __dir__ + '/../../ruby/grammar/scopes'
 Treetop.load __dir__ + '/../../ruby/grammar/emerald'
 
 #


### PR DESCRIPTION
Probably we should better handle cases when a `with` is a string or something, since I don't guard against that.

...and also some rubocop changes, because `%w()` starts getting to some perl-level unreadability and I think `!!` boolean casting is fine.

@AndrewMcBurney @icechen1 