### PR TITLE
Add new comment style to grammar

### DIFF
--- a/lib/emerald/grammar/emerald.tt
+++ b/lib/emerald/grammar/emerald.tt
@@ -34,7 +34,8 @@ grammar Emerald
   # Single line and multiline comments
   rule comment
     space* '!' ( !"\n" . )* "\n" <Comment> /
-    space* '<!' ( !"!>" . )* "!>\n" <Comment>
+    space* '<!' ( !"!>" . )* "!>\n" <Comment> /
+    space* '*' text_content newline <Comment>
   end
 
   # TODO: add escape characters

--- a/lib/emerald/nodes/Comment.rb
+++ b/lib/emerald/nodes/Comment.rb
@@ -7,6 +7,6 @@ require_relative 'Node'
 # Prints out the value of the comment's text
 class Comment < Node
   def to_html(_context)
-    "<!-- #{elements[2].text_value} -->"
+    "<!-- #{elements[2].text_value} -->\n"
   end
 end

--- a/sample.emr
+++ b/sample.emr
@@ -1,4 +1,4 @@
-// Emerald Language
+* Emerald Language
 
 doctype html
 

--- a/spec/preprocessor/emerald/general/sample.emr
+++ b/spec/preprocessor/emerald/general/sample.emr
@@ -1,6 +1,6 @@
 ! doctype 5
 
-<! emerald sample !>
+* emerald sample
 
 html
   head

--- a/spec/preprocessor/intermediate/general/sample.txt
+++ b/spec/preprocessor/intermediate/general/sample.txt
@@ -1,5 +1,5 @@
 ! doctype 5
-<! emerald sample !>
+* emerald sample
 html
 {
 head


### PR DESCRIPTION
Addresses #11

For some reason this doesn't work for multi-line literals? Any idea why? :(