### PR TITLE
New comment multiline

### DIFF
--- a/lib/emerald/grammar/emerald.tt
+++ b/lib/emerald/grammar/emerald.tt
@@ -33,9 +33,7 @@ grammar Emerald
 
   # Single line and multiline comments
   rule comment
-    space* '!' ( !"\n" . )* "\n" <Comment> /
-    space* '<!' ( !"!>" . )* "!>\n" <Comment> /
-    space* '*' text_content newline <Comment>
+    space* '*' space* text_content <Comment>
   end
 
   # Ex. h1 "test this out."

--- a/lib/emerald/grammar/emerald.tt
+++ b/lib/emerald/grammar/emerald.tt
@@ -34,7 +34,8 @@ grammar Emerald
   # Single line and multiline comments
   rule comment
     space* '!' ( !"\n" . )* "\n" <Comment> /
-    space* '<!' ( !"!>" . )* "!>\n" <Comment>
+    space* '<!' ( !"!>" . )* "!>\n" <Comment> /
+    space* '*' text_content newline <Comment>
   end
 
   # Ex. h1 "test this out."

--- a/lib/emerald/nodes/Comment.rb
+++ b/lib/emerald/nodes/Comment.rb
@@ -6,7 +6,7 @@ require_relative 'Node'
 
 # Prints out the value of the comment's text
 class Comment < Node
-  def to_html(_context)
-    "<!-- #{elements[2].text_value} -->\n"
+  def to_html(context)
+    "<!-- #{text_content.to_html(context)} -->\n"
   end
 end

--- a/lib/emerald/nodes/Comment.rb
+++ b/lib/emerald/nodes/Comment.rb
@@ -7,6 +7,6 @@ require_relative 'Node'
 # Prints out the value of the comment's text
 class Comment < Node
   def to_html(_context)
-    "<!-- #{elements[2].text_value} -->"
+    "<!-- #{elements[2].text_value} -->\n"
   end
 end

--- a/lib/emerald/nodes/Line.rb
+++ b/lib/emerald/nodes/Line.rb
@@ -9,10 +9,6 @@ class Line < Node
   def to_html(context)
     e = elements[0]
 
-    unless e.is_a?(TagStatement) || e.is_a?(Text)
-      raise "well you shouldn't be here :("
-    end
-
     e.to_html(context)
   end
 end

--- a/sample.emr
+++ b/sample.emr
@@ -1,4 +1,4 @@
-// Emerald Language
+* Emerald Language
 
 doctype html
 

--- a/spec/functional/general_spec.rb
+++ b/spec/functional/general_spec.rb
@@ -49,4 +49,29 @@ describe Emerald do
       )
     ).to eq('<section class="something">here\'s some text (and some stuff in brackets)</section>')
   end
+
+  it 'supports single line comments' do
+    expect(
+      convert(
+        context: {},
+        input: <<~EMR,
+          * test
+          h1 test
+        EMR
+      )
+    ).to eq('<!-- test --> <h1>test</h1>')
+  end
+
+  it 'supports multiline comments' do
+    expect(
+      convert(
+        context: {},
+        input: <<~EMR,
+          * ->
+            test
+          h1 test
+        EMR
+      )
+    ).to eq('<!-- test --> <h1>test</h1>')
+  end
 end

--- a/spec/preprocessor/emerald/general/sample.emr
+++ b/spec/preprocessor/emerald/general/sample.emr
@@ -1,6 +1,6 @@
 ! doctype 5
 
-<! emerald sample !>
+* emerald sample
 
 html
   head

--- a/spec/preprocessor/intermediate/general/sample.txt
+++ b/spec/preprocessor/intermediate/general/sample.txt
@@ -1,5 +1,5 @@
 ! doctype 5
-<! emerald sample !>
+* emerald sample
 html
 {
 head


### PR DESCRIPTION
Adding on to @icechen1's changes in https://github.com/emerald-lang/emerald/pull/26:
- Adds a space after the `*` (this is what stopped multiline literals from parsing I think)
- use `.to_html` on the `text_content` node so that it supports variable templating (idk why we would need this but why not??)
- added tests for multiline syntax
- Removed the old comment syntax