### PR TITLE
Misc bug fixes

### DIFF
--- a/lib/emerald/grammar/emerald.tt
+++ b/lib/emerald/grammar/emerald.tt
@@ -65,7 +65,7 @@ grammar Emerald
   end
 
   rule tag_statement
-    (tag / h_num) space* body:text_content? attr_list? <TagStatement>
+    tag space* body:text_content? attr_list? <TagStatement>
   end
 
   rule attr_list

--- a/lib/emerald/grammar/tokens.tt
+++ b/lib/emerald/grammar/tokens.tt
@@ -7,44 +7,12 @@ grammar Tokens
     'metas' / 'scripts' / 'styles'
   end
 
-  rule h_num
-    'h1' &space / 'h2' &space / 'h3' &space / 'h4' &space / 'h5' &space / 'h6' &space
-  end
-
   rule tag
-    'a' / 'abbr' / 'address' / 'area' / 'article' / 'aside' / 'audio' / 'body' /
-    'base' / 'bdi' / 'bdo' / 'blockquote' / 'br' / 'b' / 'button' /
-    'canvas' / 'caption' / 'cite' / 'code' / 'col' / 'colgroup' / 'datalist' /
-    'dd' / 'del' / 'details' / 'dfn' / 'dialog' / 'div' / 'dl' / 'em' /
-    'embed' / 'fieldset' / 'figcaption' / 'figure' / 'footer' / 'form' /
-    'header' / 'head' / 'hr' / 'html' / 'i' / 'iframe' / 'img' / 'input' /
-    'ins' / 'kbd' / 'keygen' / 'label' / 'legend' / 'li' / 'link' / 'main' /
-    'map' / 'mark' / 'menu' / 'menuitem' / 'meta' / 'meter' / 'nav' /
-    'noscript' / 'object' / 'ol' / 'optgroup' / 'option' / 'output' / 'p' /
-    'param' / 'pre' / 'progress' / 'q' / 'rp' / 'rt' / 'ruby' / 'section' / 'samp' /
-    'script' / 'select' / 'small' / 'source' / 'span' / 's' / 'strong' /
-    'style' / 'sub' / 'summary' / 'sup' / 'table' / 'tbody' / 'td' /
-    'textarea' / 'tfoot' / 'th' / 'thead' / 'time' / 'title' / 'tr' / 'track' /
-    'u' / 'ul' / 'var' / 'video' / 'wbr'
+    [a-z] [a-z1-9]*
   end
 
   rule attr
-    'accept' / 'accept-charset' / 'accesskey' / 'action' / 'alt' / 'async' /
-    'autocomplete' / 'autofocus' / 'autoplay' / 'challenge' / 'charset' /
-    'checked' / 'cite' / 'class' / 'cols' / 'colspan' / 'content' /
-    'contenteditable' / 'contextmenu' / 'controls' / 'coords' / 'data' /
-    'data-(.+?)' / 'datetime' / 'default' / 'defer' / 'dir' / 'dirname' /
-    'disabled' / 'download' / 'draggable' / 'dropzone' / 'enctype' / 'for' /
-    'form' /'formaction' / 'headers' / 'height' / 'hidden' / 'high' / 'href' /
-    'hreflang' / 'http-equiv' / 'id' / 'ismap' / 'keytype' / 'kind' / 'label' /
-    'lang' / 'list' / 'loop' / 'low' / 'manifest' / 'max' / 'maxlength' /
-    'media' / 'method' / 'min' / 'multiple' / 'muted' / 'name' / 'novalidate' /
-    'open' / 'optimum' / 'pattern' / 'placeholder' / 'poster' / 'preload' /
-    'readonly' / 'rel' / 'required' / 'reversed' / 'rows' / 'rowspan' /
-    'sandbox' / 'scope' / 'scoped' / 'selected' / 'shape' / 'size' / 'sizes' /
-    'span' / 'spellcheck' / 'src' / 'srcdoc' / 'srclang' / 'start' / 'step' /
-    'style' / 'tabindex' / 'target' / 'title' / 'translate' / 'type' /
-    'usemap' / 'value' / 'width' / 'wrap'
+    [a-z\-_]+
   end
 
   rule event

--- a/lib/emerald/nodes/Nested.rb
+++ b/lib/emerald/nodes/Nested.rb
@@ -10,8 +10,8 @@ require_relative 'Node'
 #
 class Nested < Node
   def to_html(context)
-    elements[0].to_html_tag(context) +
+    elements[0].opening_tag(context) +
       elements[4].to_html(context) +
-      "</#{elements[0].elements[0].text_value}>"
+      elements[0].closing_tag(context)
   end
 end

--- a/lib/emerald/nodes/TagStatement.rb
+++ b/lib/emerald/nodes/TagStatement.rb
@@ -7,14 +7,7 @@ require_relative 'Node'
 # A tag
 class TagStatement < Node
   def to_html(context)
-    "<#{elements[0].text_value}" +
-      (
-        if !elements[3].empty?
-          elements[3].to_html(context)
-        else
-          ''
-        end
-      ) + '>' +
+    opening_tag(context) +
       (
         if !body.empty?
           body.to_html(context)
@@ -22,10 +15,21 @@ class TagStatement < Node
           ''
         end
       ) +
-      "</#{elements[0].text_value}>"
+      closing_tag(context)
   end
 
-  def to_html_tag(_context)
-    "<#{elements[0].text_value}>"
+  def opening_tag(context)
+    "<#{elements[0].text_value}" +
+      (
+        if !elements[3].empty?
+          elements[3].to_html(context)
+        else
+          ''
+        end
+      ) + '>'
+  end
+
+  def closing_tag(_context)
+    "</#{elements[0].text_value}>"
   end
 end

--- a/spec/functional/general_spec.rb
+++ b/spec/functional/general_spec.rb
@@ -4,6 +4,20 @@
 require 'spec_helper'
 
 describe Emerald do
+  it 'supports nested tags with attributes' do
+    expect(
+      convert(
+        context: {},
+        input: <<~EMR,
+          section (
+            class "something"
+          )
+            h1 Test
+        EMR
+      )
+    ).to eq('<section class="something"><h1>Test</h1></section>')
+  end
+
   it 'text rule works with attributes' do
     expect(
       convert(

--- a/spec/functional/templating_spec.rb
+++ b/spec/functional/templating_spec.rb
@@ -59,14 +59,14 @@ describe Emerald do
       convert(
         context: {name: 'Dave'},
         input: <<~EMR,
-          h1 ->
+          pre ->
             Hello, world,
             my name is |name|
         EMR
       )
     ).to eq(whitespace_agnostic(<<~HTML))
-      <h1>Hello, world,
-      my name is Dave</h1>
+      <pre>Hello, world,
+      my name is Dave</pre>
     HTML
   end
 


### PR DESCRIPTION
- It was parsing some tags weirdly (e.g. an h1 could have text content but a pre wouldn't for some reason), but I think the better solution is to just match generic tag and attribute names. Reasoning:
  - You can make arbitrary `data-` prefixed attributes, this is valid html
  - this will let us parse custom components later
  - we should probably keep semantic validation out of the grammar anyway
- It wasn't adding attributes to nested tags, this fixes that