### PR TITLE
Escape HTML entities by default

### DIFF
--- a/emerald.gemspec
+++ b/emerald.gemspec
@@ -31,9 +31,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'test-unit'
-  spec.add_development_dependency 'thor'
-  spec.add_development_dependency 'treetop'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'pre-commit'
-  spec.add_development_dependency 'htmlbeautifier', '~> 1.1', '>= 1.1.1'
+
+  spec.add_runtime_dependency 'htmlentities'
+  spec.add_runtime_dependency 'treetop'
+  spec.add_runtime_dependency 'thor'
+  spec.add_runtime_dependency 'htmlbeautifier', '~> 1.1', '>= 1.1.1'
 end

--- a/lib/emerald/grammar/emerald.tt
+++ b/lib/emerald/grammar/emerald.tt
@@ -47,7 +47,7 @@ grammar Emerald
   end
 
   rule multiline_templateless_literal
-    "=>" space* newline
+    ("=>" / "~>") space* newline
     body:(escaped / !'$' .)*
     "$" <TextLiteral>
   end

--- a/spec/functional/templating_spec.rb
+++ b/spec/functional/templating_spec.rb
@@ -133,7 +133,7 @@ describe Emerald do
       ).to eq('<h1>hey look a brace }</h1>')
     end
 
-    it 'does not alter templateless literals' do
+    it 'does not template templateless literals' do
       expect(
         convert(
           context: {},
@@ -146,7 +146,7 @@ describe Emerald do
         )
       ).to eq(whitespace_agnostic(<<~HTML))
         <h1>if (a || b) {
-          console.log("truthy\\n");
+          console.log(&quot;truthy\\n&quot;);
         }</h1>
       HTML
     end

--- a/spec/preprocessor/emerald/events/events.emr
+++ b/spec/preprocessor/emerald/events/events.emr
@@ -4,9 +4,9 @@ html
 
   body
     button (
-      click ->
+      click ~>
         alert("I was clicked")
-      hover ->
+      hover ~>
         alert("I was hovered")
     )
 

--- a/spec/preprocessor/intermediate/events/events.txt
+++ b/spec/preprocessor/intermediate/events/events.txt
@@ -8,10 +8,10 @@ body
 {
 button (
 {
-click ->
+click ~>
 alert("I was clicked")
 $
-hover ->
+hover ~>
 alert("I was hovered")
 $
 }

--- a/spec/preprocessor/preprocessor_spec.rb
+++ b/spec/preprocessor/preprocessor_spec.rb
@@ -69,6 +69,32 @@ describe Emerald::PreProcessor do
       expect(preprocess(input)).to eq(output)
     end
 
+    it 'encodes html entities' do
+      input = <<~EMR
+        h1 =>
+          <div>
+      EMR
+      output = whitespace_agnostic <<~PREPROCESSED
+        h1 =>
+        &lt;div&gt;
+        $
+      PREPROCESSED
+      expect(preprocess(input)).to eq(output)
+    end
+
+    it 'does not encode html entities for ~> literals' do
+      input = <<~EMR
+        h1 ~>
+          <div>
+      EMR
+      output = whitespace_agnostic <<~PREPROCESSED
+        h1 ~>
+        <div>
+        $
+      PREPROCESSED
+      expect(preprocess(input)).to eq(output)
+    end
+
     it 'escapes dollar signs' do
       input = <<~EMR
         h1 =>


### PR DESCRIPTION
Lets you use `~>` for unescaped literals.

May need to reconsider the symbol used for this later though: https://github.com/emerald-lang/emerald/issues/38