### PR TITLE
Error messages

### DIFF
--- a/lib/emerald/grammar.rb
+++ b/lib/emerald/grammar.rb
@@ -18,39 +18,73 @@ Treetop.load __dir__ + '/grammar/emerald'
 # failure if there was an error when parsing. Returns an abstract syntax tree.
 #
 module Grammar
+  # When the parser fails on a line from user input
+  class ParserError < StandardError
+    LINES_BEFORE = 3
+    LINES_AFTER = 1
+
+    def initialize(line_number, reason, source)
+      @line_number = line_number
+      @reason = reason
+      @source = source
+    end
+
+    def message
+      messages = []
+      if match = @reason.match(/(Expected .+?) at line/)
+        messages << match[1]
+      else
+        messages << @reason
+      end
+
+      lines = @source.split(/\n/)
+      LINES_BEFORE.downto(1).each do |i|
+        messages << '    ' + lines[@line_number - i] if lines[@line_number - i]
+      end
+      messages << '>>> ' + lines[@line_number]
+      1.upto(LINES_AFTER).each do |i|
+        messages << '    ' + lines[@line_number + i] if lines[@line_number + i]
+      end
+
+      messages.join("\n")
+    end
+  end
+
+  # When the parser fails on a line added only in preprocessing
+  class PreProcessorError < ParserError
+    def say
+      messages = []
+      messages << "Error parsing in pre-processed Emerald. This is likely a bug."
+      messages << @reason
+      messages.concat(@source.lines.with_index { |line, i| puts "#{i + 1} #{line}" })
+
+      messages.join("\n")
+    end
+  end
+
   @parser = EmeraldParser.new
 
   # Parse the preprocessed emerald text and print failure if it fails the
   # parsing stage
-  def self.parse_grammar(text, debug: false, verbose: false)
+  def self.parse_grammar(text, original, source_map)
     parsed = @parser.parse(text)
 
-    if debug
-      if parsed.nil?
-        print_failure(text)
-      elsif verbose
-        print_passed(text)
+    if parsed.nil?
+      source_line = source_map[@parser.failure_line][:source_line]
+      if source_line.nil?
+        raise PreProcessorError.new(
+          @parser.failure_line,
+          @parser.failure_reason,
+          text
+        )
       end
+      raise ParserError.new(
+        source_line,
+        @parser.failure_reason,
+        original
+      )
     end
 
     parsed
-  end
-
-  # Print out faliure reason and lines
-  def self.print_failure(text)
-    puts "Failed:\n"
-    puts '===================================='
-    text.each_line.with_index { |line, i| puts "#{i + 1} #{line}" }
-    puts "====================================\n\n"
-    puts @parser.failure_reason
-    puts "\n"
-  end
-
-  # Print success
-  def self.print_passed(text)
-    puts "Passed:\n"
-    puts '===================================='
-    puts text
-    puts "====================================\n\n"
   end
 end

--- a/lib/emerald/grammar.rb
+++ b/lib/emerald/grammar.rb
@@ -39,11 +39,11 @@ module Grammar
 
       lines = @source.split(/\n/)
       LINES_BEFORE.downto(1).each do |i|
-        messages << '    ' + lines[@line_number - i] if lines[@line_number - i]
+        messages << '    ' + lines[@line_number - i - 1] if lines[@line_number - i - 1]
       end
-      messages << '>>> ' + lines[@line_number]
+      messages << '>>> ' + lines[@line_number - 1]
       1.upto(LINES_AFTER).each do |i|
-        messages << '    ' + lines[@line_number + i] if lines[@line_number + i]
+        messages << '    ' + lines[@line_number + i - 1] if lines[@line_number + i - 1]
       end
 
       messages.join("\n")

--- a/lib/emerald/preprocessor.rb
+++ b/lib/emerald/preprocessor.rb
@@ -45,7 +45,7 @@ module Emerald
         check_new_indent(new_indent)
         @output += remove_indent_whitespace(line)
         @source_map[@output.lines.length] = {
-          source_line: line_number
+          source_line: line_number + 1
         }
         check_and_enter_literal(line)
       end

--- a/lib/emerald/preprocessor.rb
+++ b/lib/emerald/preprocessor.rb
@@ -23,12 +23,13 @@ module Emerald
       @b_count = 0
       @output = ''
       @encoder = HTMLEntities.new
+      @source_map = {}
     end
 
     # Process the emerald to remove indentation and replace with brace convention
     # for an easier time parsing with context free grammar
     def process_emerald(input)
-      input.each_line do |line|
+      input.each_line.with_index do |line, line_number|
         if @in_literal
           if line[0...-1].empty?
             new_indent = @current_indent
@@ -43,12 +44,15 @@ module Emerald
 
         check_new_indent(new_indent)
         @output += remove_indent_whitespace(line)
+        @source_map[@output.lines.length] = {
+          source_line: line_number
+        }
         check_and_enter_literal(line)
       end
 
       close_tags(0)
 
-      @output
+      [@output, @source_map]
     end
 
     # Compares the value of the new_indent with the old indentation.

--- a/spec/emerald_spec.rb
+++ b/spec/emerald_spec.rb
@@ -5,4 +5,18 @@ describe Emerald do
   it 'has a version number' do
     expect(Emerald::VERSION).not_to be nil
   end
+
+  it 'shows meaningful errors' do
+    input = <<~EMR
+      html
+        body
+          h1 Hello, world (
+            class something
+          )
+          p Test
+    EMR
+    expect{ Emerald.convert(input) }.to raise_error(Grammar::ParserError) do |e|
+      expect(e.message).to include('>>>       class something')
+    end
+  end
 end

--- a/spec/preprocessor/preprocessor_spec.rb
+++ b/spec/preprocessor/preprocessor_spec.rb
@@ -26,7 +26,7 @@ def get_new_hash(hash, file, new_path)
   if File.directory?(new_path)
     walk(new_path, true, hash)
   else
-    hash[file[/[^\.]+/]] = Emerald::PreProcessor.new.process_emerald(IO.read(new_path))
+    hash[file[/[^\.]+/]], _ = Emerald::PreProcessor.new.process_emerald(IO.read(new_path))
   end
 
   hash
@@ -52,6 +52,20 @@ describe Emerald::PreProcessor do
   output.each do |key, value|
     it "works for #{key}" do
       expect(value).to eq(expected[key])
+    end
+  end
+
+  context 'source maps' do
+    it 'maps lines from output to input' do
+      input = <<~EMR
+        div
+          h1 Test
+      EMR
+      map = {
+        1 => {source_line: 1},
+        3 => {source_line: 2}
+      }
+      expect(source_map(input)).to eq(map)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ def whitespace_agnostic(str)
 end
 
 def convert(context:, input:, preserve_whitespace: false)
-  output = Emerald.convert(input, context, debug: true)
+  output = Emerald.convert(input, context)
   unless preserve_whitespace
     whitespace_agnostic output
   else
@@ -16,10 +16,15 @@ def convert(context:, input:, preserve_whitespace: false)
 end
 
 def preprocess(input, preserve_whitespace: false)
-  output = Emerald::PreProcessor.new.process_emerald(input)
+  output, _ = Emerald::PreProcessor.new.process_emerald(input)
   unless preserve_whitespace
     whitespace_agnostic output
   else
     output
   end
+end
+
+def source_map(input)
+  _, map = Emerald::PreProcessor.new.process_emerald(input)
+  map
 end


### PR DESCRIPTION
e.g. for
```
html
  body
    h1 Test (
      class something
    )
    p Hello, world!
```
you get the output:
```
Expected one of ' ', '"'
    html
      body
        h1 Test (
>>>       class something
        )
```

If the error is on a line not in the source map, it's a line the preprocessor added, so it is likely a preprocessor bug and shows the full file with line numbers.

The source map format is a hash for each line, in case we add column-level map information into this later.