### PR TITLE
Add peglib grammar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /spec/reports/
 /tmp/
 bin/pre-commit
+tags

--- a/cpp/src/grammar.cpp
+++ b/cpp/src/grammar.cpp
@@ -10,7 +10,7 @@
 Grammar::Grammar() : emerald_parser(syntax) {
 
   emerald_parser["ROOT"] = [](const peg::SemanticValues& sv) -> std::string {
-    return "todo: make this real output";
+    return sv.str();
   };
 
   emerald_parser.enable_packrat_parsing();
@@ -24,8 +24,7 @@ peg::parser Grammar::get_parser() {
 }
 
 bool Grammar::valid(const std::string &input) {
-  std::cout << input << std::endl;
   std::string output;
   emerald_parser.parse(input.c_str(), output);
-  return output != "";
+  return output.length() == input.length();
 }

--- a/cpp/src/grammar.cpp
+++ b/cpp/src/grammar.cpp
@@ -9,12 +9,11 @@
  */
 Grammar::Grammar() : emerald_parser(syntax) {
 
-  emerald_parser["NUMBER"] = [](const peg::SemanticValues& sv) -> int {
-    return stoi(sv.token(), nullptr, 10);
+  emerald_parser["ROOT"] = [](const peg::SemanticValues& sv) -> std::string {
+    return "todo: make this real output";
   };
 
   emerald_parser.enable_packrat_parsing();
-
 }
 
 /**
@@ -22,4 +21,11 @@ Grammar::Grammar() : emerald_parser(syntax) {
  */
 peg::parser Grammar::get_parser() {
   return emerald_parser;
+}
+
+bool Grammar::valid(const std::string &input) {
+  std::cout << input << std::endl;
+  std::string output;
+  emerald_parser.parse(input.c_str(), output);
+  return output != "";
 }

--- a/cpp/src/grammar.hpp
+++ b/cpp/src/grammar.hpp
@@ -24,6 +24,8 @@ public:
 
   peg::parser get_parser();
 
+  bool valid(const std::string &input);
+
 protected:
   Grammar();
 
@@ -33,15 +35,19 @@ private:
   // PEG parser
   peg::parser emerald_parser;
 
+public:
   // Grammar rules
-  static constexpr const auto syntax = R"(
-    # Non-terminal nodes
-    ROOT               <- NUMBER / LPAREN / RPAREN
-    NUMBER             <- < [0-9]+ >
-    LPAREN             <- '('
-    RPAREN             <- ')'
-    %whitespace        <- [ \t]*
-  )";
+  static constexpr const auto syntax =
+    #include "grammar.peg"
+      "\n"
+    #include "tokens.peg"
+      "\n"
+    #include "scopes.peg"
+      "\n"
+    #include "variables.peg"
+      "\n"
+    R"(%whitespace        <- [ \t]*)"
+  ;
 
 };
 

--- a/cpp/src/grammar.hpp
+++ b/cpp/src/grammar.hpp
@@ -35,7 +35,6 @@ private:
   // PEG parser
   peg::parser emerald_parser;
 
-public:
   // Grammar rules
   static constexpr const auto syntax =
     #include "grammar.peg"

--- a/cpp/src/grammar.peg
+++ b/cpp/src/grammar.peg
@@ -1,9 +1,9 @@
 R"(
 ROOT               <- (scope / pair_list / value_list / nested / line / comment)+
 
-nested             <- tag_statement nl lbrace nl main rbrace nl
+nested             <- tag_statement nl lbrace nl ROOT rbrace nl
 
-scope              <- $fn< scope_fn > lbrace nl $body< main > rbrace nl
+scope              <- $fn< scope_fn > lbrace nl $body< ROOT > rbrace nl
 
 line               <- (tag_statement / comment) nl
 
@@ -21,15 +21,15 @@ ml_templess_lit    <- ('=>' / '~>') space* nl $body< (escaped / !'$' .)* > '$'
 
 inline_literal     <- $body< (variable / escaped / !lparen !nl .)* >
 
-inline_lit_str     <- ''' $body< (variable / escaped / !''' .)* > '''
+inline_lit_str     <- '"' $body< (variable / escaped / !'"' .)* > '"'
 
-escaped            <- '\' .
+escaped            <- '\\' .
 
-tag_statement      <- tag $identifier< id_name? > $classes< class_name* > space* $body< text_Content? > $attributes< attr_list? >
+tag_statement      <- tag $identifier< id_name? > $classes< class_name* > space* $body< text_content? > $attributes< attr_list? >
 
-id_name            <- '#' $name< [a-zA-Z_\-]+ >
+id_name            <- '#' $name< ([a-zA-Z_] / '-')+ >
 
-class_name         <- '.' $name< [a-zA-X_\-]+ >
+class_name         <- '.' $name< ([a-zA-X_] / '-')+ >
 
 attr_list          <- lparen nl lbrace nl attributes rbrace nl rparen
 

--- a/cpp/src/grammar.peg
+++ b/cpp/src/grammar.peg
@@ -3,33 +3,33 @@ ROOT               <- (scope / pair_list / value_list / nested / line / comment)
 
 nested             <- tag_statement nl lbrace nl main rbrace nl
 
-scope              <- $fn<scope_fn> lbrace nl $body<main> rbrace nl
+scope              <- $fn< scope_fn > lbrace nl $body< main > rbrace nl
 
 line               <- (tag_statement / comment) nl
 
-value_list         <- $keyword<special_keyword> nl lbrace nl $list_items<($literal<inline_lit_str> nl)+> rbrace nl
+value_list         <- $keyword< special_keyword > nl lbrace nl $list_items< ($literal< inline_lit_str > nl)+ > rbrace nl
 
-pair_list          <- $keyword<base_keyword> nl lbrace nl $list_items<($pairs<($attr<attr> space+ $literal<inline_lit_str> space*)+> nl)+> rbrace nl
+pair_list          <- $keyword< base_keyword > nl lbrace nl $list_items< ($pairs< ($attr< attr > space+ $literal< inline_lit_str > space*)+ > nl)+ > rbrace nl
 
 comment            <- space* '*' space* text_content
 
 text_content       <- multiline_literal / ml_templess_lit / inline_literal
 
-multiline_literal  <- "->" space* nl $body<(variable / escaped / !'$' .)*> "$"
+multiline_literal  <- '->' space* nl $body< (variable / escaped / !'$' .)* > '$'
 
-ml_templess_lit    <- ("=>" / "~>") space* nl $body<(escaped / !'$' .)*> "$"
+ml_templess_lit    <- ('=>' / '~>') space* nl $body< (escaped / !'$' .)* > '$'
 
-inline_literal     <- $body<(variable / escaped / !lparen !nl .)*>
+inline_literal     <- $body< (variable / escaped / !lparen !nl .)* >
 
-inline_lit_str     <- '"' $body<(variable / escaped / !'"' .)*> '"'
+inline_lit_str     <- ''' $body< (variable / escaped / !''' .)* > '''
 
-escaped            <- "\" .
+escaped            <- '\' .
 
-tag_statement      <- tag $identifier<id_name?> $classes<class_name*> space* $body<text_Content?> $attributes<attr_list?>
+tag_statement      <- tag $identifier< id_name? > $classes< class_name* > space* $body< text_Content? > $attributes< attr_list? >
 
-id_name            <- '#' $name<[a-zA-Z_\-]+>
+id_name            <- '#' $name< [a-zA-Z_\-]+ >
 
-class_name         <- '.' $name<[a=zA-X_\-]+>
+class_name         <- '.' $name< [a-zA-X_\-]+ >
 
 attr_list          <- lparen nl lbrace nl attributes rbrace nl rparen
 

--- a/cpp/src/grammar.peg
+++ b/cpp/src/grammar.peg
@@ -1,0 +1,39 @@
+R"(
+ROOT               <- (scope / pair_list / value_list / nested / line / comment)+
+
+nested             <- tag_statement nl lbrace nl main rbrace nl
+
+scope              <- $fn<scope_fn> lbrace nl $body<main> rbrace nl
+
+line               <- (tag_statement / comment) nl
+
+value_list         <- $keyword<special_keyword> nl lbrace nl $list_items<($literal<inline_lit_str> nl)+> rbrace nl
+
+pair_list          <- $keyword<base_keyword> nl lbrace nl $list_items<($pairs<($attr<attr> space+ $literal<inline_lit_str> space*)+> nl)+> rbrace nl
+
+comment            <- space* '*' space* text_content
+
+text_content       <- multiline_literal / ml_templess_lit / inline_literal
+
+multiline_literal  <- "->" space* nl $body<(variable / escaped / !'$' .)*> "$"
+
+ml_templess_lit    <- ("=>" / "~>") space* nl $body<(escaped / !'$' .)*> "$"
+
+inline_literal     <- $body<(variable / escaped / !lparen !nl .)*>
+
+inline_lit_str     <- '"' $body<(variable / escaped / !'"' .)*> '"'
+
+escaped            <- "\" .
+
+tag_statement      <- tag $identifier<id_name?> $classes<class_name*> space* $body<text_Content?> $attributes<attr_list?>
+
+id_name            <- '#' $name<[a-zA-Z_\-]+>
+
+class_name         <- '.' $name<[a=zA-X_\-]+>
+
+attr_list          <- lparen nl lbrace nl attributes rbrace nl rparen
+
+attributes         <- attribute*
+
+attribute          <- attr space* inline_lit_str nl
+)"

--- a/cpp/src/preprocessor.cpp
+++ b/cpp/src/preprocessor.cpp
@@ -44,7 +44,7 @@ void PreProcessor::process(std::vector<std::string> lines) {
 
   int new_indent;
 
-  for (unsigned int line_number = 0; line_number < lines.size(); line_number++) {
+  for (int line_number = 0; line_number < lines.size(); line_number++) {
     std::string &line = lines[line_number];
 
     if (in_literal) {

--- a/cpp/src/preprocessor.cpp
+++ b/cpp/src/preprocessor.cpp
@@ -44,7 +44,7 @@ void PreProcessor::process(std::vector<std::string> lines) {
 
   int new_indent;
 
-  for (int line_number = 0; line_number < lines.size(); line_number++) {
+  for (unsigned int line_number = 0; line_number < lines.size(); line_number++) {
     std::string &line = lines[line_number];
 
     if (in_literal) {

--- a/cpp/src/preprocessor.cpp
+++ b/cpp/src/preprocessor.cpp
@@ -110,7 +110,7 @@ void PreProcessor::close_literal(const int& new_indent) {
   output += "$\n";
   in_literal = false;
 
-  for (int i = 2; i < (current_indent - new_indent) / 2; i++) {
+  for (int i = 2; i <= (current_indent - new_indent) / 2; i++) {
     output += "}\n";
     unclosed_indents--;
   }

--- a/cpp/src/scopes.peg
+++ b/cpp/src/scopes.peg
@@ -1,17 +1,17 @@
 R"(
 scope_fn     <- (given / unless / each / with) nl
 
-given        <- "given" space* boolean_expr
+given        <- 'given' space* boolean_expr
 
-unless       <- "unless" space* boolean_expr
+unless       <- 'unless' space* boolean_expr
 
-with         <- "with" space* variable_name
+with         <- 'with' space* variable_name
 
-each         <- "each" space* $collection<variable_name> space* "as" space* $val_name<variable_name> $indexed<(',' space* $key_name<variable_name>)?>
+each         <- 'each' space* $collection< variable_name > space* 'as' space* $val_name< variable_name > $indexed< (',' space* $key_name< variable_name >)? >
 
 boolean_expr <- binary_expr / unary_expr
 
-binary_expr  <- $lhs<unary_expr> space+ $op<"and" / "or"> space+ $rhs<boolean_expr>
+binary_expr  <- $lhs< unary_expr > space+ $op< 'and' / 'or' > space+ $rhs< boolean_expr >
 
-unary_expr   <- $negated<("not" space+)?> ($val<variable_name> / '(' space* $val<boolean_expr> space* ')')
+unary_expr   <- $negated< ('not' space+)? > ($val< variable_name > / '(' space* $val< boolean_expr > space* ')')
 )"

--- a/cpp/src/scopes.peg
+++ b/cpp/src/scopes.peg
@@ -1,0 +1,17 @@
+R"(
+scope_fn     <- (given / unless / each / with) nl
+
+given        <- "given" space* boolean_expr
+
+unless       <- "unless" space* boolean_expr
+
+with         <- "with" space* variable_name
+
+each         <- "each" space* $collection<variable_name> space* "as" space* $val_name<variable_name> $indexed<(',' space* $key_name<variable_name>)?>
+
+boolean_expr <- binary_expr / unary_expr
+
+binary_expr  <- $lhs<unary_expr> space+ $op<"and" / "or"> space+ $rhs<boolean_expr>
+
+unary_expr   <- $negated<("not" space+)?> ($val<variable_name> / '(' space* $val<boolean_expr> space* ')')
+)"

--- a/cpp/src/tokens.peg
+++ b/cpp/src/tokens.peg
@@ -1,0 +1,27 @@
+R"(
+base_keyword        <- 'images' / 'metas' / 'scripts' / 'styles'
+
+special_keyword     <- 'images' / 'scripts' / 'styles'
+
+tag                 <- [a-z] [a-z1-9]*
+
+attr                <- [a-z\-_]+
+
+event               <- 'onabort' / 'onclick' / 'onhover' / 'onbeforeprint' / 'onbeforeunload'
+
+equals              <- '='
+
+comma               <- ','
+
+lparen              <- '('
+
+rparen              <- ')'
+
+lbrace              <- '{'
+
+rbrace              <- '}'
+
+space               <- ' '
+
+nl                  <- [\n]
+)"

--- a/cpp/src/tokens.peg
+++ b/cpp/src/tokens.peg
@@ -5,7 +5,7 @@ special_keyword     <- 'images' / 'scripts' / 'styles'
 
 tag                 <- [a-z] [a-z1-9]*
 
-attr                <- [a-z\-_]+
+attr                <- ([a-z_] / '-')+
 
 event               <- 'onabort' / 'onclick' / 'onhover' / 'onbeforeprint' / 'onbeforeunload'
 

--- a/cpp/src/variables.peg
+++ b/cpp/src/variables.peg
@@ -1,0 +1,5 @@
+R"(
+variable      <- '|' variable_name '|'
+
+variable_name <- [a-zA-Z0-9_]+ ('.' variable_name)*
+)"

--- a/cpp/test/emerald_tests.cpp
+++ b/cpp/test/emerald_tests.cpp
@@ -6,9 +6,26 @@
 
 TEST_CASE("accepting valid Emerald", "[grammar]") {
   std::vector<std::string> input = {
-    "div =>",
-    "  test"
+    "html",
+    "  body",
+    "    h1 Hello, world (",
+    "      class \"something\"",
+    "    )",
+    "    p Test"
   };
 
   REQUIRE(Grammar::get_instance().valid(PreProcessor(input).get_output()));
+}
+
+TEST_CASE("failing invalid Emerald", "[grammar]") {
+  std::vector<std::string> input = {
+    "html",
+    "  body",
+    "    h1 Hello, world (",
+    "      class something",
+    "    )",
+    "    p Test"
+  };
+
+  REQUIRE(!Grammar::get_instance().valid(PreProcessor(input).get_output()));
 }

--- a/cpp/test/emerald_tests.cpp
+++ b/cpp/test/emerald_tests.cpp
@@ -1,10 +1,14 @@
 #define CATCH_CONFIG_MAIN
 
 #include "test_helper.hpp"
+#include "../src/preprocessor.hpp"
+#include "../src/grammar.hpp"
 
-TEST_CASE("Test PreProcessor produces expected results", "[vector]") {
+TEST_CASE("accepting valid Emerald", "[grammar]") {
+  std::vector<std::string> input = {
+    "div =>",
+    "  test"
+  };
 
-  // Test assertions
-  REQUIRE(true == true);
-
+  REQUIRE(Grammar::get_instance().valid(PreProcessor(input).get_output()));
 }

--- a/cpp/test/emerald_tests.cpp
+++ b/cpp/test/emerald_tests.cpp
@@ -14,7 +14,8 @@ TEST_CASE("accepting valid Emerald", "[grammar]") {
     "    p Test"
   };
 
-  REQUIRE(Grammar::get_instance().valid(PreProcessor(input).get_output()));
+  PreProcessor p(input);
+  REQUIRE(Grammar::get_instance().valid(p.get_output()));
 }
 
 TEST_CASE("failing invalid Emerald", "[grammar]") {
@@ -27,5 +28,6 @@ TEST_CASE("failing invalid Emerald", "[grammar]") {
     "    p Test"
   };
 
-  REQUIRE(!Grammar::get_instance().valid(PreProcessor(input).get_output()));
+  PreProcessor p(input);
+  REQUIRE(!Grammar::get_instance().valid(p.get_output()));
 }

--- a/cpp/test/preprocessor_tests.cpp
+++ b/cpp/test/preprocessor_tests.cpp
@@ -102,3 +102,37 @@ TEST_CASE("multiline literals", "[preprocessor]") {
     REQUIRE(p.get_output() == TestHelper::concat(output));
   }
 }
+
+TEST_CASE("converting nesting") {
+  SECTION("adding braces around nested tags") {
+    std::vector<std::string> input = {
+      "div",
+      "  p test"
+    };
+    std::vector<std::string> output = {
+      "div",
+      "{",
+      "p test",
+      "}"
+    };
+    PreProcessor p(input);
+    REQUIRE(p.get_output() == concat(output));
+  }
+
+  SECTION("adding braces around attributes") {
+    std::vector<std::string> input = {
+      "h1 test (",
+      "  class \"title\"",
+      ")"
+    };
+    std::vector<std::string> output = {
+      "h1 test (",
+      "{",
+      "class \"title\"",
+      "}",
+      ")"
+    };
+    PreProcessor p(input);
+    REQUIRE(p.get_output() == concat(output));
+  }
+}

--- a/cpp/test/preprocessor_tests.cpp
+++ b/cpp/test/preprocessor_tests.cpp
@@ -116,7 +116,7 @@ TEST_CASE("converting nesting") {
       "}"
     };
     PreProcessor p(input);
-    REQUIRE(p.get_output() == concat(output));
+    REQUIRE(p.get_output() == TestHelper::concat(output));
   }
 
   SECTION("adding braces around attributes") {
@@ -133,6 +133,6 @@ TEST_CASE("converting nesting") {
       ")"
     };
     PreProcessor p(input);
-    REQUIRE(p.get_output() == concat(output));
+    REQUIRE(p.get_output() == TestHelper::concat(output));
   }
 }


### PR DESCRIPTION
This converts our old Treetop grammar to a Peglib grammar. Since Peglib expects a string as input, the peg files need to get concatenated into a single string. Each `.peg` file is a C++ string literal (hence the `R"( ... )"` surrounding the contents of each.)

This also adds more tests to the preprocessor to ensure bracketing happens correctly.