### PR TITLE
Use a GCC version supported by our json library on CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,10 @@ machine:
 
 dependencies:
   pre:
+    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt-get update
+    - sudo apt-get update; sudo apt-get install gcc-4.9; sudo apt-get install g++-4.9
+    - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 100
+    - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 100
     - sudo apt-get install libboost-all-dev
   override:
     - bundle install:


### PR DESCRIPTION
This uses gcc-4.9 so that our tests run again.