### PR TITLE
Updated PreProcessor logic.

### DIFF
--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -48,6 +48,7 @@ void exit_and_error() {
 int main(int argc, char** argv) {
   if (argc < 1) print_usage();
 
+  PreProcessor processor;
   std::string line, parsed;
   std::vector<std::string> lines;
 
@@ -63,8 +64,7 @@ int main(int argc, char** argv) {
     while (std::getline(input_file, line)) lines.push_back(line);
 
     // Preprocess the emerald source code
-    PreProcessor processor(lines);
-    std::string output = processor.get_output();
+    std::string output = processor.process(lines);
 
     // Get parser member from singleton 'Grammar' class
     peg::parser parser = Grammar::get_instance().get_parser();

--- a/cpp/src/preprocessor.cpp
+++ b/cpp/src/preprocessor.cpp
@@ -54,6 +54,9 @@ std::string PreProcessor::process(std::vector<std::string> lines) {
 
 /**
  * To accommodate empty lines in multiline literals which are part of the literal
+ *
+ * NOTE: Normally, we just discard blank lines. But in literals, we want to
+ * preserve spacing, but also not consider it a dedent
  */
 void PreProcessor::process_line_in_literal(std::string& line, int& new_indent) {
   if (line.substr(0, line.length() - 1).empty()) {
@@ -104,18 +107,14 @@ void PreProcessor::close_tags(const int& new_indent) {
 void PreProcessor::close_literal(const int& new_indent) {
   output += "$\n";
   in_literal = false;
-
-  for (int i = 2; i <= (current_indent - new_indent) / 2; i++) {
-    output += "}\n";
-    unclosed_indents--;
-  }
+  close_entered_tags(new_indent, 2);
 }
 
 /**
  * Append closing braces if not in literal and new indent is less than old one
  */
-void PreProcessor::close_entered_tags(const int& new_indent) {
-  for (int i = 1; i <= (current_indent - new_indent) / 2; i++) {
+void PreProcessor::close_entered_tags(const int& new_indent, int index) {
+  for (int i = index; i <= (current_indent - new_indent) / 2; i++) {
     output += "}\n";
     unclosed_indents--;
   }

--- a/cpp/src/preprocessor.hpp
+++ b/cpp/src/preprocessor.hpp
@@ -11,12 +11,12 @@
 class PreProcessor {
 
 public:
-  PreProcessor(std::vector<std::string>);
-  std::string get_output();
+  PreProcessor();
+  std::string process(std::vector<std::string>);
   std::map<int, int> get_source_map();
 
 private:
-  void process(std::vector<std::string>);
+  void process_line_in_literal(std::string&, int&);
   void check_new_indent(const int&);
   void open_tags(const int&);
   void close_tags(const int&);
@@ -29,6 +29,7 @@ private:
   int current_indent, unclosed_indents;
   std::string output;
   std::map<int, int> source_map;
+
 };
 
 #endif // PREPROCESSOR_H

--- a/cpp/src/preprocessor.hpp
+++ b/cpp/src/preprocessor.hpp
@@ -21,7 +21,7 @@ private:
   void open_tags(const int&);
   void close_tags(const int&);
   void close_literal(const int&);
-  void close_entered_tags(const int&);
+  void close_entered_tags(const int&, int = 1);
   std::string remove_indent_whitespace(std::string);
   void check_and_enter_literal(const std::string&);
 

--- a/cpp/test/emerald_tests.cpp
+++ b/cpp/test/emerald_tests.cpp
@@ -1,7 +1,6 @@
 #define CATCH_CONFIG_MAIN
 
 #include "test_helper.hpp"
-#include "../src/preprocessor.hpp"
 #include "../src/grammar.hpp"
 
 TEST_CASE("accepting valid Emerald", "[grammar]") {
@@ -14,8 +13,8 @@ TEST_CASE("accepting valid Emerald", "[grammar]") {
     "    p Test"
   };
 
-  PreProcessor p(input);
-  REQUIRE(Grammar::get_instance().valid(p.get_output()));
+  PreProcessor p;
+  REQUIRE(Grammar::get_instance().valid(p.process(input)));
 }
 
 TEST_CASE("failing invalid Emerald", "[grammar]") {
@@ -28,6 +27,6 @@ TEST_CASE("failing invalid Emerald", "[grammar]") {
     "    p Test"
   };
 
-  PreProcessor p(input);
-  REQUIRE(!Grammar::get_instance().valid(p.get_output()));
+  PreProcessor p;
+  REQUIRE(!Grammar::get_instance().valid(p.process(input)));
 }

--- a/cpp/test/preprocessor_tests.cpp
+++ b/cpp/test/preprocessor_tests.cpp
@@ -2,18 +2,23 @@
 #include "../src/preprocessor.hpp"
 
 TEST_CASE("source maps", "[preprocessor]") {
+
   SECTION("mapping lines from output to input") {
     std::vector<std::string> input = {
       "div",
       "  test"
     };
-    PreProcessor p(input);
+
+    PreProcessor p;
+    p.process(input);
     REQUIRE(p.get_source_map()[1] == 1);
     REQUIRE(p.get_source_map()[3] == 2);
   }
-}
+
+} // TEST_CASE("source maps", "[preprocessor]")
 
 TEST_CASE("multiline literals", "[preprocessor]") {
+
   SECTION("preprocessing multiline literals") {
     std::vector<std::string> input = {
       "h1 =>",
@@ -24,8 +29,9 @@ TEST_CASE("multiline literals", "[preprocessor]") {
       "This is a multiline literal",
       "$"
     };
-    PreProcessor p(input);
-    REQUIRE(p.get_output() == TestHelper::concat(output));
+
+    PreProcessor p;
+    REQUIRE(p.process(input) == TestHelper::concat(output));
   }
 
   SECTION("encoding HTML entities") {
@@ -38,8 +44,9 @@ TEST_CASE("multiline literals", "[preprocessor]") {
       "&lt;div&gt;",
       "$"
     };
-    PreProcessor p(input);
-    REQUIRE(p.get_output() == TestHelper::concat(output));
+
+    PreProcessor p;
+    REQUIRE(p.process(input) == TestHelper::concat(output));
   }
 
   SECTION("encoding utf8 characters without semantic names") {
@@ -52,8 +59,9 @@ TEST_CASE("multiline literals", "[preprocessor]") {
       "&#128076;",
       "$"
     };
-    PreProcessor p(input);
-    REQUIRE(p.get_output() == TestHelper::concat(output));
+
+    PreProcessor p;
+    REQUIRE(p.process(input) == TestHelper::concat(output));
   }
 
   SECTION("skipping HTML entity encoding for ~> literals") {
@@ -66,8 +74,9 @@ TEST_CASE("multiline literals", "[preprocessor]") {
       "<div>",
       "$"
     };
-    PreProcessor p(input);
-    REQUIRE(p.get_output() == TestHelper::concat(output));
+
+    PreProcessor p;
+    REQUIRE(p.process(input) == TestHelper::concat(output));
   }
 
   SECTION("escaping dollar signs") {
@@ -80,8 +89,9 @@ TEST_CASE("multiline literals", "[preprocessor]") {
       "Thi\\$ i\\$ a multiline literal",
       "$"
     };
-    PreProcessor p(input);
-    REQUIRE(p.get_output() == TestHelper::concat(output));
+
+    PreProcessor p;
+    REQUIRE(p.process(input) == TestHelper::concat(output));
   }
 
   SECTION("preserving empty lines") {
@@ -98,12 +108,15 @@ TEST_CASE("multiline literals", "[preprocessor]") {
       "line",
       "$"
     };
-    PreProcessor p(input);
-    REQUIRE(p.get_output() == TestHelper::concat(output));
+
+    PreProcessor p;
+    REQUIRE(p.process(input) == TestHelper::concat(output));
   }
-}
+
+} // TEST_CASE("multiline literals", "[preprocessor]")
 
 TEST_CASE("converting nesting") {
+
   SECTION("adding braces around nested tags") {
     std::vector<std::string> input = {
       "div",
@@ -115,8 +128,9 @@ TEST_CASE("converting nesting") {
       "p test",
       "}"
     };
-    PreProcessor p(input);
-    REQUIRE(p.get_output() == TestHelper::concat(output));
+
+    PreProcessor p;
+    REQUIRE(p.process(input) == TestHelper::concat(output));
   }
 
   SECTION("adding braces around attributes") {
@@ -132,7 +146,9 @@ TEST_CASE("converting nesting") {
       "}",
       ")"
     };
-    PreProcessor p(input);
-    REQUIRE(p.get_output() == TestHelper::concat(output));
+
+    PreProcessor p;
+    REQUIRE(p.process(input) == TestHelper::concat(output));
   }
-}
+
+} // TEST_CASE("converting nesting")

--- a/cpp/test/templating_tests.cpp
+++ b/cpp/test/templating_tests.cpp
@@ -82,7 +82,7 @@ TEST_CASE("templating", "[grammar]") {
       std::vector<std::string> input = {
         "h1 Hello, \\\\||name|"
       };
-      const char *output = "<h1>Hello, \Dave</h1>";
+      const char *output = "<h1>Hello, \\Dave</h1>";
 
       REQUIRE(TestHelper::convert(input, { "name", "Dave" }) == output);
     }

--- a/cpp/test/test_helper.hpp
+++ b/cpp/test/test_helper.hpp
@@ -3,6 +3,7 @@
 
 #include "../lib/catch.hpp"
 #include "../lib/json.hpp"
+#include "../src/grammar.hpp"
 #include "../src/preprocessor.hpp"
 
 #include <string>


### PR DESCRIPTION
## Changes
- Removed `get_output` method in favour of returning output upon processing the emerald (in `process`)
- Use a `std::transform` to modify vector of `std::string` lines in place of the naive iteration/mutation I wrote before
- Added method `void PreProcessor::process_line_in_literal(std::string& line, int& new_indent)` to break up the `process` method - since it was kinda big
- Updated tests to accommodate changes

## Side note
- We should probably fix tests so they are actually useful :joy:
