### PR TITLE
Add text literal nodes

### DIFF
--- a/cpp/src/grammar.peg
+++ b/cpp/src/grammar.peg
@@ -21,13 +21,19 @@ comment            <- space* '*' space* text_content
 
 text_content       <- multiline_literal / ml_templess_lit / inline_literal
 
-multiline_literal  <- '->' space* nl $body< (variable / escaped / !'$' .)* > '$'
+multiline_literal  <- ~'->' ~space* ~nl (variable / escaped / ml_lit_content)* ~'$'
 
-ml_templess_lit    <- ('=>' / '~>') space* nl $body< (escaped / !'$' .)* > '$'
+ml_templess_lit    <- ~('=>' / '~>') ~space* ~nl (escaped / ml_lit_content)* ~'$'
 
-inline_literal     <- $body< (variable / escaped / !lparen !nl .)* >
+inline_literal     <- (variable / escaped / il_lit_content)*
 
-inline_lit_str     <- '"' $body< (variable / escaped / !'"' .)* > '"'
+inline_lit_str     <- ~'"' (variable / escaped / il_lit_content)* ~'"'
+
+ml_lit_content     <- !'$' .
+
+il_lit_content     <- !lparen !nl .
+
+il_lit_str_content <- !'"' .
 
 escaped            <- '\\' .
 

--- a/cpp/src/nodes/escaped.cpp
+++ b/cpp/src/nodes/escaped.cpp
@@ -1,0 +1,8 @@
+#include "escaped.hpp"
+
+Escaped::Escaped(std::string content) : content(content) {}
+
+std::string Escaped::to_html(Json &context) {
+  // Unescape the string
+  return content.substr(1);
+}

--- a/cpp/src/nodes/escaped.hpp
+++ b/cpp/src/nodes/escaped.hpp
@@ -1,0 +1,18 @@
+#ifndef ESCAPED_H
+#define ESCAPED_H
+
+#include "node.hpp"
+
+class Escaped : public Node {
+
+public:
+  Escaped(std::string content);
+
+  std::string to_html(Json &context) override;
+
+private:
+  std::string content;
+
+};
+
+#endif // ESCAPED_H

--- a/cpp/src/nodes/text_literal.cpp
+++ b/cpp/src/nodes/text_literal.cpp
@@ -1,0 +1,11 @@
+#include "text_literal.hpp"
+#include <boost/algorithm/string/join.hpp>
+
+TextLiteral::TextLiteral(NodePtrs body) : body(body) {}
+
+std::string TextLiteral::to_html(Json &context) {
+  std::vector<std::string> converted;
+  std::transform(body.begin(), body.end(), converted.begin(),
+      [&](NodePtr element) -> std::string { return element->to_html(context); });
+  return boost::algorithm::join(converted, "");
+}

--- a/cpp/src/nodes/text_literal.hpp
+++ b/cpp/src/nodes/text_literal.hpp
@@ -1,0 +1,18 @@
+#ifndef TEXTLITERAL_H
+#define TEXTLITERAL_H
+
+#include "node.hpp"
+
+class TextLiteral : public Node {
+
+public:
+  TextLiteral(NodePtrs body);
+
+  std::string to_html(Json &context) override;
+
+private:
+  NodePtrs body;
+
+};
+
+#endif // TEXTLITERAL_H

--- a/cpp/src/nodes/text_literal_content.cpp
+++ b/cpp/src/nodes/text_literal_content.cpp
@@ -1,0 +1,7 @@
+#include "text_literal_content.hpp"
+
+TextLiteralContent::TextLiteralContent(std::string content) : content(content) {}
+
+std::string TextLiteralContent::to_html(Json &context) {
+  return content;
+}

--- a/cpp/src/nodes/text_literal_content.hpp
+++ b/cpp/src/nodes/text_literal_content.hpp
@@ -1,0 +1,18 @@
+#ifndef TEXTLITERALCONTENT_H
+#define TEXTLITERALCONTENT_H
+
+#include "node.hpp"
+
+class TextLiteralContent : public Node {
+
+public:
+  TextLiteralContent(std::string content);
+
+  std::string to_html(Json &context) override;
+
+private:
+  std::string content;
+
+};
+
+#endif // TEXTLITERALCONTENT_H

--- a/cpp/util/generator.rb
+++ b/cpp/util/generator.rb
@@ -65,7 +65,7 @@ module Emerald
       EOF
 
       update_file("src/grammar.cpp", "#include \"nodes/#{name}.hpp\"\n", "// [END] Include nodes")
-      update_file("src/grammar.cpp", grammar_rule, "emerald_parser.enable_packrat_parsing();")
+      update_file("src/grammar.cpp", grammar_rule, "// Terminals")
     end
 
     private


### PR DESCRIPTION
This adds support for text literals. Rather than what we were doing in Ruby where `TextLiteral` checks the class of each element in its `body` and renders it accordingly, it now makes each body element a `Node` which can just have `to_html` called on it. This forces regular "dumb" strings to have a class that just returns itself, but everything else is nicer.