### PR TITLE
Make repeated() return a function

### DIFF
--- a/cpp/src/grammar.cpp
+++ b/cpp/src/grammar.cpp
@@ -43,15 +43,16 @@ namespace {
   // Helper to turn the repeated (+ or *) ith token into a vector of
   // a given type
   template<typename T>
-  std::vector<T> repeated(const peg::SemanticValues& sv, size_t i) {
-    std::vector<T> contents;
-    const peg::SemanticValues repeated_node = sv[i].get<peg::SemanticValues>();
+  std::function<std::vector<T>(const peg::SemanticValues&)> repeated() {
+    return [](const peg::SemanticValues& sv) -> std::vector<T> {
+      std::vector<T> contents;
 
-    for (unsigned int n = 0; n < repeated_node.size(); n++) {
-      contents.push_back(repeated_node[n].get<T>());
-    }
+      for (unsigned int n = 0; n < sv.size(); n++) {
+        contents.push_back(sv[n].get<T>());
+      }
 
-    return contents;
+      return contents;
+    };
   }
 }
 


### PR DESCRIPTION
We will need to make plural rules for every `+` or `*` so that they are in their own rule.

## Usage:

Instead of:
```
some_rule <- thing+ other_thing
```

Do:
```
some_rule <- things other_thing
things <- thing+
```

```c++
emerald_parser["things"] = repeated<NodePtr>();
emerald_parser["some_rule"] = [](const peg::SemanticValues& sv) -> NodePtr {
  std::vector<NodePtr> things = sv[0].get<std::vector<NodePtr>>();
  return NodePtr(new SomeRule(things));
};
```