### PR TITLE
Fix helper for optional nodes

### DIFF
--- a/cpp/src/grammar.cpp
+++ b/cpp/src/grammar.cpp
@@ -34,7 +34,7 @@
 namespace {
   // Helper function to turn a maybe rule (one element, made optional with a ?) into its value or a default
   template<typename T>
-   std::function<T(const peg::SemanticValues&)> optional(T default_value) {
+  std::function<T(const peg::SemanticValues&)> optional(T default_value) {
     return [=](const peg::SemanticValues &sv) -> T {
       if (sv.size() > 0) {
         return sv[0].get<T>();

--- a/cpp/src/grammar.cpp
+++ b/cpp/src/grammar.cpp
@@ -127,11 +127,13 @@ Grammar::Grammar() : emerald_parser(syntax) {
 
   emerald_parser["maybe_id_name"] = optional<std::string>("");
 
+  emerald_parser["class_names"] = repeated<std::string>();
+
   emerald_parser["tag_statement"] =
     [](const peg::SemanticValues& sv) -> NodePtr {
       std::string tag_name = sv[0].get<std::string>();
       std::string id_name = sv[1].get<std::string>();
-      std::vector<std::string> class_names = repeated<std::string>(sv, 2);
+      std::vector<std::string> class_names = sv[2].get<std::vector<std::string>>();
       NodePtr body = sv[3].get<NodePtr>();
       NodePtr attributes = sv[4].get<NodePtr>();
       NodePtr nested = sv[5].get<NodePtr>();
@@ -142,7 +144,7 @@ Grammar::Grammar() : emerald_parser(syntax) {
 
   emerald_parser["attr_list"] =
     [](const peg::SemanticValues& sv) -> NodePtr {
-      NodePtrs nodes = repeated<NodePtr>(sv, 0);
+      NodePtrs nodes = sv[0].get<NodePtrs>();
 
       return NodePtr(new Attributes(nodes));
     };
@@ -258,7 +260,7 @@ Grammar::Grammar() : emerald_parser(syntax) {
   // Repeated Nodes
   const std::vector<std::string> repeated_nodes = {
     "statements", "literal_new_lines", "key_value_pairs", "ml_lit_str_quoteds",
-    "ml_templess_lit_str_qs", "inline_literals", "il_lit_str_quoteds"
+    "ml_templess_lit_str_qs", "inline_literals", "il_lit_str_quoteds", "attributes"
   };
   for (std::string repeated_node : repeated_nodes) {
     emerald_parser[repeated_node.c_str()] = repeated<NodePtr>();
@@ -283,7 +285,7 @@ Grammar::Grammar() : emerald_parser(syntax) {
   for (std::string string_rule : literals) {
     emerald_parser[string_rule.c_str()] =
       [](const peg::SemanticValues& sv) -> NodePtr {
-        NodePtrs body = repeated<NodePtr>(sv, 0);
+        NodePtrs body = sv[0].get<NodePtrs>();
 
         return NodePtr(new NodeList(body, ""));
       };

--- a/cpp/src/grammar.cpp
+++ b/cpp/src/grammar.cpp
@@ -18,7 +18,6 @@
 #include "nodes/tag_statement.hpp"
 #include "nodes/text_literal_content.hpp"
 #include "nodes/escaped.hpp"
-#include "nodes/pair_list.hpp"
 #include "nodes/comment.hpp"
 #include "nodes/scoped_key_value_pairs.hpp"
 #include "nodes/key_value_pair.hpp"
@@ -33,14 +32,19 @@
 // [END] Include nodes
 
 namespace {
-  // Helper function to check if the optional (?) ith token in a rule
-  // matched anything
-  bool present(const peg::SemanticValues& sv, size_t i) {
-    return !sv.token(i).empty();
+  // Helper function to turn a maybe rule (one element, made optional with a ?) into its value or a default
+  template<typename T>
+  T optional(T default_value) {
+    return [=](const peg::SemanticValues &sv) -> T {
+      if (sv.size() > 0) {
+        return sv[0].get<T>();
+      } else {
+        return default_value;
+      }
+    };
   }
 
-  // Helper to turn the repeated (+ or *) ith token into a vector of
-  // a given type
+  // Helper to turn plural rules (one element, repeated with + or *) into a vector of a given type
   template<typename T>
   std::function<std::vector<T>(const peg::SemanticValues&)> repeated() {
     return [](const peg::SemanticValues& sv) -> std::vector<T> {

--- a/cpp/src/grammar.peg
+++ b/cpp/src/grammar.peg
@@ -25,6 +25,8 @@ key_value_pair         <- attr ~space+ inline_lit_str space*
 
 comment                <- ~space* ~'*' ~space* text_content
 
+maybe_text_content     <- text_content?
+
 text_content           <- multiline_literal / ml_templess_lit / inline_literals_node
 
 multiline_literal      <- ~'->' ~space* ~nl ml_lit_str_quoteds ~'$'
@@ -64,13 +66,21 @@ il_lit_str_content     <- !'"' .
 
 escaped                <- '\\' .
 
-tag_statement          <- tag id_name? class_names ~space* text_content? attr_list? (~nl ~lbrace ~nl ROOT ~rbrace ~nl)?
+tag_statement          <- tag maybe_id_name class_names ~space* maybe_text_content maybe_attr_list maybe_nested_tag
+
+maybe_nested_tag       <- nested_tag?
+
+nested_tag             <- ~nl ~lbrace ~nl ROOT ~rbrace ~nl
+
+maybe_id_name          <- id_name?
 
 id_name                <- '#' $name< ([a-zA-Z_] / '-')+ >
 
 class_names            <- class_name*
 
 class_name             <- '.' $name< ([a-zA-Z_] / '-')+ >
+
+maybe_attr_list        <- attr_list?
 
 attr_list              <- ~lparen ~nl ~lbrace ~nl attributes ~rbrace ~nl ~rparen
 

--- a/cpp/src/scopes.peg
+++ b/cpp/src/scopes.peg
@@ -1,17 +1,25 @@
 R"(
-scope_fn     <- (given / unless / each / with) ~nl
+scope_fn       <- (given / unless / each / with) ~nl
 
-given        <- ~'given' ~space* boolean_expr
+given          <- ~'given' ~space* boolean_expr
 
-unless       <- ~'unless' ~space* boolean_expr
+unless         <- ~'unless' ~space* boolean_expr
 
-with         <- ~'with' ~space* variable_name
+with           <- ~'with' ~space* variable_name
 
-each         <- ~'each' ~space* variable_name ~space* ~'as' ~space* ~variable_name (~',' ~space* ~variable_name)? >
+each           <- ~'each' ~space* variable_name ~space* ~'as' ~space* ~variable_name maybe_key_name >
 
-boolean_expr <- binary_expr / unary_expr
+maybe_key_name <- key_name?
 
-binary_expr  <- unary_expr ~space+ ('and' / 'or') ~space+ boolean_expr
+key_name       <- ~',' ~space* variable_name
 
-unary_expr   <- ('not' space+)? (variable_name / ~'(' ~space* boolean_expr ~space* ~')')
+boolean_expr   <- binary_expr / unary_expr
+
+binary_expr    <- unary_expr ~space+ ('and' / 'or') ~space+ boolean_expr
+
+unary_expr     <- maybe_negation (variable_name / ~'(' ~space* boolean_expr ~space* ~')')
+
+maybe_negation <- negation?
+
+negation       <- 'not' space+
 )"


### PR DESCRIPTION
## Usage

Change:
```
some_rule <- something? other_thing
```

Into:
```
some_rule <- maybe_something other_thing
maybe_something <- something?
```

```c++
emerald_parser["some_rule"] = [](const peg::SemanticValues& sv) -> NodePtr {
  NodePtr maybe_something = sv[0].get<NodePtr>();
  NodePtr other_thing = sv[1].get<NodePtr>();
  return NodePtr(new SomeRule(maybe_something, other_thing));
};
emerald_parser["maybe_something"] = optional<NodePtr>(NodePtr()); // default to empty NodePtr
```